### PR TITLE
Tweaks (#21)

### DIFF
--- a/css/lpress/pages/_cookies.pcss
+++ b/css/lpress/pages/_cookies.pcss
@@ -16,7 +16,7 @@
 
 		&:after {
 			content: "";
-			top: 0.0625rem;
+			top: rem(1px);
 			@apply absolute h-6 w-6 bg-white rounded-full block border-2 border-primary;
 			transition: background-color 0.4s ease;
 		}
@@ -28,7 +28,7 @@
 		}
 
 		&:checked + .toggle-label:after {
-			left: 2rem;
+			left: rem(2);
 		}
 
 		&:checked + .toggle-label .on {

--- a/css/lpress/shared/_cta.pcss
+++ b/css/lpress/shared/_cta.pcss
@@ -1,16 +1,16 @@
 .cta-area {
 	.cta {
-		@media (min-width: 640px) {
+		@media (min-width: theme('screens.sm')) {
 			grid-template-columns: rem(305px) 1fr;
 		}
 
-		@media (min-width: 1024px) {
+		@media (min-width: theme('screens.md')) {
 			grid-template-columns: rem(305px) 1fr rem(250px);
 		}
 	}
 
 	.button-area {
-		@media (max-width: 768px) {
+		@media (max-width: theme('screens.md')) {
 			.button {
 				@apply py-1.5 px-3 -text-ms-1;
 			}

--- a/css/lpress/shared/_directional.pcss
+++ b/css/lpress/shared/_directional.pcss
@@ -2,7 +2,7 @@
 	@apply flex flex-col border border-grey-300 rounded-md shadow;
 
 	.image {
-		@apply flex-full flex-0-auto align-bottom  border-b-8 border-grey-300;
+		@apply grow-0 shrink-0 basis-auto align-bottom  border-b-8 border-grey-300;
 
 		img {
 			@apply rounded-t-md;
@@ -10,7 +10,7 @@
 	}
 
 	.text-area {
-		@apply text-center flex flex-1-0-auto flex-col p-3 lg:px-6;
+		@apply text-center flex grow shrink-0 basis-auto flex-col p-3 lg:px-6;
 
 		.title {
 			@apply text-ms-5 font-bold mb-3;
@@ -26,6 +26,6 @@
 	}
 
 	.footer {
-		@apply flex flex-col flex-1-0-auto justify-end mb-6;
+		@apply flex flex-col grow shrink-0 basis-auto justify-end mb-6;
 	}
 }

--- a/css/lpress/shared/_layout.pcss
+++ b/css/lpress/shared/_layout.pcss
@@ -1,8 +1,8 @@
 .site-header,
 .site-footer {
-	@apply flex-0-auto;
+	@apply grow-0 shrink-0 basis-auto;
 }
 
 .site-main {
-	@apply flex-shrink-0 flex-grow;
+	@apply grow shrink-0 basis-auto;
 }

--- a/css/lpress/shared/_nav.pcss
+++ b/css/lpress/shared/_nav.pcss
@@ -1,4 +1,4 @@
-.main-nav {
+.main-nav-area {
 	@apply z-10;
 
 	.nav-lvl-0 {
@@ -7,6 +7,11 @@
 
 	.submenu {
 		@apply bg-white text-ms-2 absolute w-48 border-primary border-b-4 text-primary;
+
+		/* Mobile submenu */
+		@media (max-width: theme('screens.xl')) {
+			@apply w-auto relative text-ms-0;
+		}
 	}
 
 	/* General navigation items, applies to all nav items */
@@ -30,8 +35,8 @@
 	}
 
 	/* Mobile navigation side menu */
-	@media (max-width: 1124px) {
-		@apply fixed bg-primary border-primary-dark border-r-4 text-white top-0 bottom-0 w-60 -left-60 opacity-0;
+	@media (max-width: theme('screens.xl')) {
+		@apply fixed bg-primary border-primary-dark text-white border-r-4 top-0 bottom-0 w-60 -left-60 opacity-0;
 		transition: left 0.4s ease, opacity 0.4s ease;
 		&.active {
 			@apply left-0 opacity-100;
@@ -44,6 +49,11 @@
 		.lvl-0 > .nav-disclosure > .nav-link,
 		.lvl-0 > .nav-link {
 			@apply text-white p-4 text-ms-0 border-primary-dark border-b w-60;
+		}
+
+		.lvl-1 > .nav-disclosure > .nav-link,
+		.lvl-1 > .nav-link {
+			@apply text-ms-0;
 		}
 	}
 }

--- a/css/lpress/shared/_social-links.pcss
+++ b/css/lpress/shared/_social-links.pcss
@@ -1,9 +1,9 @@
 .social-media-list {
-	@apply flex flex-row mt-8;
+	@apply flex flex-wrap flex-row mt-8;
 
 	.network {
 		.icon {
-			@apply h-6 w-6 flex justify-center items-center rounded bg-grey-500 mx-1;
+			@apply h-6 w-6 flex justify-center items-center rounded bg-grey-500 m-1;
 
 			svg {
 				@apply h-4 w-4 text-white fill-white;


### PR DESCRIPTION
* Adjusted rem and top on after 'toggle-label' psuedo element

* Adjuted grow and shrink classes for new tailwind upgrade

* Added new tailwind grow shrink and basis classes to layout

* Adjusted min-width size on mobile navigation

* Renames `main-nav` styling to `main-nav-area`

* Changed media queries to match with theme screens and size

* Fixed social links to have flex-wrap and adjust margin on icons

* Tweaks mobile navigation

* Tweaks cookie toggle styling

Co-authored-by: Joseph Balzac <joe@lform.com>
Co-authored-by: Brandon Fenning <brandon@lform.com>