### PR TITLE
[Fix] Class name escape (#29)

### DIFF
--- a/css/components/_flex-grid.pcss
+++ b/css/components/_flex-grid.pcss
@@ -41,7 +41,7 @@
     }
 
     /* Flex Grid Gap Definitions - Add as Needed */
-    .flex-grid-gap-0.5 {
+    .flex-grid-gap-0\.5 {
         --flex-grid-gap: 0.125rem; /* 2px */
     }
 
@@ -49,7 +49,7 @@
         --flex-grid-gap: 0.25rem; /* 4px */
     }
 
-    .flex-grid-gap-1.5 {
+    .flex-grid-gap-1\.5 {
         --flex-grid-gap: 0.375rem; /* 6px */
     }
 
@@ -57,7 +57,7 @@
         --flex-grid-gap: 0.5rem; /* 8px */
     }
 
-    .flex-grid-gap-2.5 {
+    .flex-grid-gap-2\.5 {
         --flex-grid-gap: 0.625rem; /* 10px */
     }
 
@@ -65,7 +65,7 @@
         --flex-grid-gap: 0.75rem; /* 12px */
     }
 
-    .flex-grid-gap-3.5 {
+    .flex-grid-gap-3\.5 {
         --flex-grid-gap: 0.875rem; /* 14px */
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lform/lwind",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"description": "Customized tailwind framework",
 	"main": "package.json",
 	"private": false,


### PR DESCRIPTION
* Fixes css build error by escaping "."

* Increments version number

* Flex Grid - Reverts incorrect readme merge

* Flex Grid - Reverts incorrect readme merge - Re-adds headings

---------